### PR TITLE
levelcomtempo

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ global="*res://scripts/global.gd"
 
 window/size/viewport_width=390
 window/size/viewport_height=844
+window/stretch/scale=0.5
 
 [global_group]
 

--- a/scenes/levelcomtempo/levelcomtempo.tscn
+++ b/scenes/levelcomtempo/levelcomtempo.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=3 uid="uid://cfst6x46yaxhv"]
+
+[ext_resource type="Script" uid="uid://b5dc5diro5arx" path="res://scripts/levelcomtempo/levelcomtempo.gd" id="1_y2prq"]
+[ext_resource type="PackedScene" uid="uid://dm0nv7mdhpm30" path="res://scenes/recycle_bin/recycle_bin.tscn" id="2_lrtyt"]
+[ext_resource type="PackedScene" uid="uid://cju2hkmd3d61g" path="res://scenes/trash/trash.tscn" id="3_o1vev"]
+
+[node name="levelcomtempo" type="Node2D"]
+script = ExtResource("1_y2prq")
+
+[node name="Background" type="TextureRect" parent="."]
+offset_right = 972.0
+offset_bottom = 2127.0
+scale = Vector2(0.4, 0.4)
+
+[node name="Recycle_bin" parent="." instance=ExtResource("2_lrtyt")]
+
+[node name="Trash" parent="." instance=ExtResource("3_o1vev")]
+
+[node name="LabelTempo" type="Label" parent="."]
+offset_left = 148.0
+offset_top = 31.0
+offset_right = 250.0
+offset_bottom = 54.0
+text = "TEMPO:"
+
+[node name="Timer" type="Timer" parent="."]
+autostart = true

--- a/scripts/levelcomtempo/levelcomtempo.gd
+++ b/scripts/levelcomtempo/levelcomtempo.gd
@@ -1,0 +1,137 @@
+extends Node2D
+
+@onready var recyble_bin_container: StaticBody2D = get_node("Recycle_bin")
+@onready var trash_container: Node2D = get_node("Trash")
+@onready var background: TextureRect = get_node("Background")
+@onready var label_tempo: Label = get_node("LabelTempo")
+@onready var cronometro: Timer = get_node("Timer")
+
+var tempo_em_segundos: int = 60
+
+var scenarios = [
+	"biblioteca",
+	"cidade",
+	"construcao",
+	"deserto",
+	"fazenda",
+	#falta 3 cenários que não consegui carregar no godot
+	"parque_diversao",
+	"praia"
+]
+
+var trash_types = [
+	"metal",
+	"organico",
+	"papel",
+	"plastico",
+	"vidro"
+]
+
+var scenario = ""
+var types_in_level = []
+
+var recycle_bin_scene = preload("res://scenes/recycle_bin/recycle_bin.tscn")
+var trash_scene = preload("res://scenes/trash/trash.tscn")
+
+@onready var recycle_bin_quant: int
+var destroyed_trash = 0
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	choose_scenario()
+	choose_trash_types()
+	create_recycle_bins()
+	create_trash()	
+	cronometro.connect("timeout", Callable(self, "_on_cronometro_timeout"))
+	atualizar_label()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+	
+func _on_cronometro_timeout():
+	tempo_em_segundos -= 1
+	atualizar_label()
+	
+func atualizar_label():
+	var min = tempo_em_segundos / 60
+	var seg = tempo_em_segundos % 60
+	label_tempo.text = "TEMPO: " + str("%02d:%02d" % [min, seg])
+	if tempo_em_segundos <= 0:
+		cronometro.stop()
+	
+func choose_scenario() -> void:
+	scenario = scenarios.pick_random()
+	var path = "res://assets/scenarios/%s.png" % scenario
+	background.texture = load(path)
+
+
+func choose_trash_types() -> void:
+	types_in_level = trash_types
+	types_in_level.shuffle()
+	
+	if global.player_level == 1:
+		recycle_bin_quant = 2
+	
+	elif global.player_level == 2:
+		recycle_bin_quant = 3
+		
+	elif global.player_level == 3:
+		recycle_bin_quant = 4
+
+	else:
+		recycle_bin_quant = 4
+	
+	
+	types_in_level = types_in_level.slice(0, recycle_bin_quant)
+	
+	
+func create_recycle_bins() -> void:
+	
+	var bin_spacing = 90
+	var bin_width = 80
+	
+	var total_width = (types_in_level.size() - 1) * bin_spacing + bin_width
+	
+	var start_x = (370 - total_width) / 2 + bin_width / 2
+	
+	for i in types_in_level.size():
+		var type = types_in_level[i].to_upper()
+		var recycle_bin = recycle_bin_scene.instantiate()
+		recycle_bin.type = type
+		
+		var x = start_x + i * bin_spacing
+		var y = 550
+		
+		recycle_bin.position = Vector2(x, y)
+		recyble_bin_container.add_child(recycle_bin)
+
+func create_trash():
+	if tempo_em_segundos == 0:
+		print("Fase completada")
+		return
+	
+	var random_type = types_in_level.pick_random()
+	var trash = trash_scene.instantiate()
+	trash.type = random_type
+	trash.scenario = scenario
+	trash.position = Vector2(195, 800)
+	trash_container.add_child(trash)
+	
+	trash.connect("is_on_right_bin", Callable(self, "on_trash_dropped"))
+
+func on_trash_dropped(trash):
+	destroyed_trash += 1 
+	trash.queue_free()
+	
+	if tempo_em_segundos == 0:
+		print("Acabou a fase")		
+		#apenas teste
+		global.player_level += 1
+		get_tree().reload_current_scene()
+		tempo_em_segundos = 60
+		
+		return
+		
+	else:
+		create_trash()

--- a/scripts/levelcomtempo/levelcomtempo.gd.uid
+++ b/scripts/levelcomtempo/levelcomtempo.gd.uid
@@ -1,0 +1,1 @@
+uid://b5dc5diro5arx


### PR DESCRIPTION
A fase com tempo, diferente da fase normal, não possui número limitado de lixos, é limitado apenas por tempo, e a fase só acaba quando o tempo acabar.

Essa fase deve ser feita a partir de uma nova cena no godot, e não usará a tela “level” que tem atualmente

Deverá ter um contador aparecendo no campo superior da tela que é atualizado a cada segundo que se passa.